### PR TITLE
feat: add publish parameter to CI workflows

### DIFF
--- a/.github/workflows/flutter-android.yml
+++ b/.github/workflows/flutter-android.yml
@@ -15,6 +15,11 @@ on:
         type: string
       package-name:
         type: string
+      publish:
+        description: 'Publish to Google Play Store'
+        required: false
+        default: true
+        type: boolean
     secrets:
       UPLOAD_KEYSTORE:
         required: true
@@ -80,7 +85,8 @@ jobs:
           name: app-release.aab
           path: ${{ inputs.working-directory }}/build/app/outputs/bundle/release/app-release.aab
 
-      - uses: r0adkll/upload-google-play@v1
+      - if: ${{ inputs.publish }}
+        uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: ${{ inputs.package-name }}

--- a/.github/workflows/flutter-ios.yml
+++ b/.github/workflows/flutter-ios.yml
@@ -13,6 +13,11 @@ on:
         type: string
       environment-url:
         type: string
+      publish:
+        description: 'Publish to App Store'
+        required: false
+        default: true
+        type: boolean
     secrets:
       APPSTORE_API_PRIVATE_KEY:
         required: true
@@ -79,8 +84,9 @@ jobs:
           name: release.ipa
           path: ${{ inputs.working-directory }}/build/ios/ipa
 
-      - working-directory: ${{ inputs.working-directory }}
+      - if: ${{ inputs.publish }}
+        working-directory: ${{ inputs.working-directory }}
         run: app-store-connect publish --testflight --whats-new "${{ inputs.whats-new }}"
-      - if: github.event_name == 'release'
+      - if: ${{ inputs.publish }} && github.event_name == 'release'
         working-directory: ${{ inputs.working-directory }}
         run: app-store-connect publish --app-store --whats-new "${{ inputs.whats-new }}"


### PR DESCRIPTION
This pull request introduces conditional publishing capabilities to the Flutter Android and iOS GitHub Actions workflows, allowing developers to optionally skip the publishing step to Google Play Store or App Store based on a new `publish` parameter.

- **Adds `publish` input parameter**: Both `.github/workflows/flutter-android.yml` and `.github/workflows/flutter-ios.yml` files now include a `publish` input parameter. This parameter defaults to `true` but can be set to `false` to skip the publishing steps.
- **Conditional execution of publishing steps**: In the Android workflow, the step that uploads the build to Google Play Store now only executes if `publish` is `true`. Similarly, in the iOS workflow, the steps that publish the build to TestFlight and App Store are also conditional on the `publish` parameter being `true`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/muxable/.github?shareId=bf343dd9-c3bb-4a42-a85a-c56b703d4ede).